### PR TITLE
Add Polaris Support

### DIFF
--- a/intel/envs/polaris/latest.env
+++ b/intel/envs/polaris/latest.env
@@ -1,0 +1,1 @@
+polaris_pytorch-2.8.0.dev20250407+cu128.env

--- a/intel/envs/polaris/polaris_pytorch-2.8.0.dev20250407+cu128.env
+++ b/intel/envs/polaris/polaris_pytorch-2.8.0.dev20250407+cu128.env
@@ -1,0 +1,11 @@
+source /home/ratnampa/miniforge3/etc/profile.d/conda.sh
+conda activate pytorch_cuda_nightly
+export NCCL_NET_GDR_LEVEL=PHB
+export NCCL_CROSS_NIC=1
+export NCCL_COLLNET_ENABLE=1
+export NCCL_NET="AWS Libfabric"
+export LD_LIBRARY_PATH=/soft/libraries/aws-ofi-nccl/v1.9.1-aws/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=/soft/libraries/hwloc/lib/:$LD_LIBRARY_PATH
+export FI_CXI_DISABLE_HOST_REGISTER=1
+export FI_MR_CACHE_MONITOR=userfaultfd
+export FI_CXI_DEFAULT_CQ_SIZE=131072

--- a/intel/helpers/set_ranks_deps.sh
+++ b/intel/helpers/set_ranks_deps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export LOCAL_RANK=$PALS_LOCAL_RANKID
-export RANK=$PMIX_RANK
+export RANK="${PMIX_RANK:-$PALS_RANKID}"
 
 if [ $RANK -eq 0 ]; then
     export TITAN_LOG_LEVEL=INFO
@@ -9,22 +9,23 @@ else
     export TITAN_LOG_LEVEL=ERROR
 fi
 
-# CCL affinity based on number ranks per node
-if [[ "$PALS_LOCAL_SIZE" == "12" ]]; then
-    export CCL_WORKER_AFFINITY=5,13,21,29,37,45,57,65,73,81,89,97
-elif [[ "$PALS_LOCAL_SIZE" == "8" ]]; then
-    export CCL_WORKER_AFFINITY=5,13,29,37,57,65,81,89
-elif [[ "$PALS_LOCAL_SIZE" == "6" ]]; then
-    export CCL_WORKER_AFFINITY=5,21,37,57,73,89
-elif [[ "$PALS_LOCAL_SIZE" == "4" ]]; then
-    export CCL_WORKER_AFFINITY=5,13,57,65
-elif [[ "$PALS_LOCAL_SIZE" == "2" ]]; then
-    export CCL_WORKER_AFFINITY=5,57
-elif [[ "$PALS_LOCAL_SIZE" == "1" ]]; then
-    export CCL_WORKER_AFFINITY=5
-else
-    echo "Unsupported local size"
-    exit 1
+if [[ "SYSTEM" == "aurora" ]]; then
+    # CCL affinity based on number ranks per node
+    if [[ "$PALS_LOCAL_SIZE" == "12" ]]; then
+        export CCL_WORKER_AFFINITY=5,13,21,29,37,45,57,65,73,81,89,97
+    elif [[ "$PALS_LOCAL_SIZE" == "8" ]]; then
+        export CCL_WORKER_AFFINITY=5,13,29,37,57,65,81,89
+    elif [[ "$PALS_LOCAL_SIZE" == "6" ]]; then
+        export CCL_WORKER_AFFINITY=5,21,37,57,73,89
+    elif [[ "$PALS_LOCAL_SIZE" == "4" ]]; then
+        export CCL_WORKER_AFFINITY=5,13,57,65
+    elif [[ "$PALS_LOCAL_SIZE" == "2" ]]; then
+        export CCL_WORKER_AFFINITY=5,57
+    elif [[ "$PALS_LOCAL_SIZE" == "1" ]]; then
+        export CCL_WORKER_AFFINITY=5
+    else
+        echo "Unsupported local size"
+        exit 1
+    fi
 fi
-
 $*


### PR DESCRIPTION
This PR adds support to run on Polaris A100 nodes OOB.

Example:
qsub -v LLAMA_CONFIG="llama3_8b",PPN=4,SYSTEM="polaris",PT_CONFIG="pt" -l nodes=3:ncpus=64 -l walltime=30:00 -l filesystems=home:eagle -q debug-scaling -A Intel ./run_train.sh